### PR TITLE
feat: prompt and history add, list

### DIFF
--- a/app/src/main/java/exam/master/repository/HistoryRepository.java
+++ b/app/src/main/java/exam/master/repository/HistoryRepository.java
@@ -1,0 +1,26 @@
+package exam.master.repository;
+
+import exam.master.domain.History;
+import exam.master.domain.Member;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class HistoryRepository {
+
+  private final EntityManager em;
+
+  public void save(History history){
+    em.persist(history);
+  }
+
+  public List<History> findAll(UUID memberId){
+    return em.createQuery("select h from History h where h.member.id = :memberId", History.class)
+        .setParameter("memberId", memberId)
+        .getResultList();
+  }
+}

--- a/app/src/main/java/exam/master/repository/PromptRepository.java
+++ b/app/src/main/java/exam/master/repository/PromptRepository.java
@@ -1,0 +1,28 @@
+package exam.master.repository;
+
+import exam.master.domain.History;
+import exam.master.domain.Prompt;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PromptRepository {
+
+  private final EntityManager em;
+
+  public void save(Prompt prompt){
+    em.persist(prompt);
+  }
+
+  public List<Prompt> findByHistoryId(UUID historyId) {
+    return em.createQuery("select p from Prompt p where p.history.id = :historyId", Prompt.class)
+        .setParameter("historyId", historyId)
+        .getResultList();
+  }
+
+
+}

--- a/app/src/main/java/exam/master/service/MemberService.java
+++ b/app/src/main/java/exam/master/service/MemberService.java
@@ -1,6 +1,7 @@
 package exam.master.service;
 
 import exam.master.domain.Member;
+import exam.master.repository.HistoryRepository;
 import exam.master.repository.MemberRepository;
 import exam.master.status.MemberStatus;
 import java.util.List;
@@ -8,7 +9,6 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,13 +20,19 @@ public class MemberService {
   private static final Log log = LogFactory.getLog(MemberService.class);
 
   private final MemberRepository memberRepository;
+  private final HistoryRepository historyRepository;
 
   // 등록
   @Transactional
-  public UUID join(Member member){
+  public UUID join(Member member/*, MultipartFile file*/){
 
     // 중복 회원 검증
     validateDuplicateMember(member);
+
+    // file 스토리지에 업로드 후
+//    String fileName = ;
+//    member.setProfilePhoto(fileName);
+
     memberRepository.save(member);
     return member.getMemberId();
   }
@@ -65,6 +71,10 @@ public class MemberService {
 
   // 로그인
   public Member findByEmailAndPassword (String email, String password){
-    return memberRepository.findByEmailAndPassword(email, password);
+    Member loginUser = memberRepository.findByEmailAndPassword(email, password);
+    
+    // 로그인 하면서 프롬프트 창으로 리다이렉트 하기 때문에 히스토리 리스트를 가져온다
+    loginUser.setHistories(historyRepository.findAll(loginUser.getMemberId()));
+    return loginUser;
   }
 }

--- a/app/src/main/java/exam/master/service/PromptService.java
+++ b/app/src/main/java/exam/master/service/PromptService.java
@@ -1,0 +1,47 @@
+package exam.master.service;
+
+import exam.master.domain.History;
+import exam.master.domain.Member;
+import exam.master.domain.Prompt;
+import exam.master.repository.HistoryRepository;
+import exam.master.repository.PromptRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PromptService {
+
+  private final PromptRepository promptRepository;
+  private final HistoryRepository historyRepository;
+
+  public Prompt addPrompt(Prompt prompt, UUID historyId, Member loginUser/*, MultipartFile file*/) {
+    
+    // 컨트롤러에서 프롬프트에 히스토리id를 검사
+    if (historyId == null) {
+      History history = new History();
+      history.setTitle(prompt.getPrompt());
+      history.setMember(loginUser);
+      historyRepository.save(history);
+      prompt.setHistory(history);
+    }
+
+//    file 스토리지에 업로드 후
+//    String fileName = "";
+//    prompt.setPhoto(fileName);
+
+//    베드락에 프롬프트와 사진을 보내고 응답을 받는다
+//    String answer = "";
+//    prompt.setAnswer(answer);
+
+    promptRepository.save(prompt);
+    return prompt;
+
+  }
+
+  public List<Prompt> findByHistoryId(UUID historyId){
+    return promptRepository.findByHistoryId(historyId);
+  }
+}

--- a/app/src/test/java/exam/master/service/PromptServiceTest.java
+++ b/app/src/test/java/exam/master/service/PromptServiceTest.java
@@ -1,0 +1,124 @@
+package exam.master.service;
+
+import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import exam.master.domain.Member;
+import exam.master.domain.Prompt;
+import java.util.List;
+import java.util.UUID;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@Transactional
+public class PromptServiceTest {
+  @Autowired
+  MemberService memberService;
+  @Autowired
+  PromptService promptService;
+  @Autowired
+  private static Log log = LogFactory.getLog(PromptServiceTest.class);
+
+  @Test
+  @Rollback(false)
+  public void 프롬프트_처음_추가() throws Exception {
+    //Given
+    Member member = new Member();
+    member.setEmail("kim@111");
+    member.setPassword("1111");
+    UUID saveId = memberService.join(member);
+    Prompt prompt = new Prompt();
+    prompt.setPrompt("testPrompt");
+    prompt.setAnswer("testAnswer");
+    prompt.setPhoto("testPhoto");
+    //When
+    promptService.addPrompt(prompt, null, member);
+    //Then
+  }
+
+  @Test
+  @Rollback(false)
+  public void 프롬프트_추가() throws Exception {
+    //Given
+    Member member = new Member();
+    member.setEmail("kim@111");
+    member.setPassword("1111");
+    UUID saveId = memberService.join(member);
+    Prompt prompt = new Prompt();
+    prompt.setPrompt("testPrompt");
+    prompt.setAnswer("testAnswer");
+    prompt.setPhoto("testPhoto");
+    Prompt prompt1 = new Prompt();
+    prompt1.setPrompt("testPrompt1");
+    prompt1.setAnswer("testAnswer1");
+    prompt1.setPhoto("testPhoto1");
+    //When
+    Prompt addPrompt = promptService.addPrompt(prompt, null, member);
+    prompt1.setHistory(addPrompt.getHistory());
+    promptService.addPrompt(prompt1, addPrompt.getHistory().getHistoryId(), member);
+    //Then
+  }
+
+  @Test
+  @Rollback(false)
+  public void 히스토리_리스트() throws Exception {
+    //Given
+    Member member = new Member();
+    member.setEmail("kim@111");
+    member.setPassword("1111");
+    UUID saveId = memberService.join(member);
+    Prompt prompt = new Prompt();
+    prompt.setPrompt("testPrompt");
+    prompt.setAnswer("testAnswer");
+    prompt.setPhoto("testPhoto");
+    Prompt prompt1 = new Prompt();
+    prompt1.setPrompt("testPrompt1");
+    prompt1.setAnswer("testAnswer1");
+    prompt1.setPhoto("testPhoto1");
+    Prompt addPrompt = promptService.addPrompt(prompt, null, member);
+    prompt1.setHistory(addPrompt.getHistory());
+    promptService.addPrompt(prompt1, addPrompt.getHistory().getHistoryId(), member);
+    //When
+    Member loginUser = memberService.findByEmailAndPassword("kim@111", "1111");
+    //Then
+//    log.debug(loginUser.getHistories().getFirst().getTitle());
+    System.out.println(loginUser.getHistories().getFirst().getHistoryId());
+    System.out.println(loginUser.getHistories().getFirst().getTitle());
+    System.out.println(loginUser.getHistories().getFirst().getCreatedDate());
+  }
+
+  @Test
+  @Rollback(false)
+  public void 프롬프트_리스트() throws Exception {
+    //Given
+    Member member = new Member();
+    member.setEmail("kim@111");
+    member.setPassword("1111");
+    UUID saveId = memberService.join(member);
+    Prompt prompt = new Prompt();
+    prompt.setPrompt("testPrompt");
+    prompt.setAnswer("testAnswer");
+    prompt.setPhoto("testPhoto");
+    Prompt prompt1 = new Prompt();
+    prompt1.setPrompt("testPrompt1");
+    prompt1.setAnswer("testAnswer1");
+    prompt1.setPhoto("testPhoto1");
+    Prompt addPrompt = promptService.addPrompt(prompt, null, member);
+    prompt1.setHistory(addPrompt.getHistory());
+    promptService.addPrompt(prompt1, addPrompt.getHistory().getHistoryId(), member);
+    //When
+    List<Prompt> list =  promptService.findByHistoryId(addPrompt.getHistory().getHistoryId());
+    //Then
+    System.out.println(list.get(0).getPrompt());
+    System.out.println(list.get(1).getPrompt());
+  }
+}


### PR DESCRIPTION
## 설명

Prompt와 History 테이블에 데이터를 추가, 테이블에서 목록 읽어오기

## 변경 사항

- 로그인 하면서 History 목록을 읽어온다.

## 확인 방법

변경 사항을 확인하는 방법을 설명하세요.

1. PromptServiceTest 테스트
2. MemberServiceTest 로그인 기능 테스트

## 연관된 이슈

- feat: Prompt and History 추가와 리스트 기능 추가 #12