### PR TITLE
fix: origins 허용 url 수정

### DIFF
--- a/app/src/main/java/exam/master/api/MemberApiController.java
+++ b/app/src/main/java/exam/master/api/MemberApiController.java
@@ -28,7 +28,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 //@CrossOrigin(origins = "https://weasel.kkamji.net")
 @CrossOrigin(
-    origins = "*",
+    origins = "http://localhost:5173",
     allowCredentials = "true") // 쿠키 포함 허용
 @RequestMapping("/v1")
 public class MemberApiController {


### PR DESCRIPTION
## 설명

origins "*" -> "locahost:5173"

## 변경 사항

- "*"와 credential allow는 동시 사용은 보안상 제한됨

## 확인 방법

- MemberApiController.java